### PR TITLE
Converting na values to empty string, then removing items with value …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2021-02-08
+
+### Added in 1.3.2
+
+- Fixed [issue #49](https://github.com/Senzing/stream-producer/issues/49) to handle CSV input files with empty values.
+
 ## [1.3.1] - 2021-01-20
 
 ### Added in 1.3.1

--- a/stream-producer.py
+++ b/stream-producer.py
@@ -1028,8 +1028,13 @@ class ReadFileCsvMixin():
         self.counter = 0
 
     def read(self):
-        data_frame = pandas.read_csv(self.input_url, skipinitialspace=True)
+        data_frame = pandas.read_csv(self.input_url, skipinitialspace=True, dtype=str)
+        data_frame.fillna('', inplace=True)
         for row in data_frame.to_dict(orient="records"):
+
+            # Remove items that have '' value
+            row = {i:j for i,j in row.items() if j != ''}
+
             self.counter += 1
             if self.record_min and self.counter < self.record_min:
                 continue


### PR DESCRIPTION
…of empty string

We recommend to customers to remove empty values, so we should too.

# Pull request questions

## Which issue does this address

Issue number: #49 

## Why was change needed

Empty strings were converted to N/A values causing an exception when the records was loaded

## What does change improve

All values are read in as strings, N/A values are converted to "", and we remove items a value of "" to follow our own recommendation to customers.
