### PR TITLE
Forcing a process exit (not a thread exit) when calling exit_error()

### DIFF
--- a/stream-producer.py
+++ b/stream-producer.py
@@ -866,7 +866,8 @@ def exit_error(index, *args):
     ''' Log error message and exit program. '''
     logging.error(message_error(index, *args))
     logging.error(message_error(698))
-    sys.exit(1)
+    logging.shutdown()
+    os._exit(1)
 
 
 def exit_silently():


### PR DESCRIPTION
Also flushing the logging to ensure everything gets written out

# Pull request questions

## Which issue does this address

Issue number: #27 

## Why was change needed

The container would hang if there were errors making the initial connections to the RabbitMQ server (and probably other queue types as well.)

## What does change improve

Forces a process exit after flushing the log so the container can be restarted if desired.
